### PR TITLE
fix: race condition on drag and click event

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,67 +1,101 @@
 'use client';
 
-import { ColumnType, Item } from '@/@types/item';
+import { useRef, useState } from 'react';
 import { Column } from '@/components/Column';
 import { initialItems } from '@/constant/item';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { ColumnType, Item } from '@/@types/item';
 
 export default function Page() {
   const [mainList, setMainList] = useState<Item[]>(initialItems);
   const [fruitList, setFruitList] = useState<Item[]>([]);
   const [vegetableList, setVegetableList] = useState<Item[]>([]);
 
+  const transitionMapRef = useRef<Map<string, NodeJS.Timeout>>(
+    new Map()
+  );
+
   const listSetters: Record<
     ColumnType,
-    Dispatch<SetStateAction<Item[]>>
+    React.Dispatch<React.SetStateAction<Item[]>>
   > = {
     Main: setMainList,
     Fruit: setFruitList,
     Vegetable: setVegetableList,
   };
 
+  const isItemLocked = (item: Item) =>
+    transitionMapRef.current.has(item.name);
+
+  const lockItem = (
+    item: Item,
+    timeoutMs: number = 5000,
+    onExpire?: () => void
+  ) => {
+    if (isItemLocked(item)) return;
+
+    const timer = setTimeout(() => {
+      transitionMapRef.current.delete(item.name);
+      onExpire?.();
+    }, timeoutMs);
+
+    transitionMapRef.current.set(item.name, timer);
+  };
+
+  const cancelLock = (item: Item) => {
+    const timer = transitionMapRef.current.get(item.name);
+    if (timer) {
+      clearTimeout(timer);
+      transitionMapRef.current.delete(item.name);
+    }
+  };
+
   const moveItemBetweenLists = (
     item: Item,
     from: ColumnType,
-    to: ColumnType
+    to: ColumnType,
+    delayBackToMain = false
   ) => {
+    if (isItemLocked(item)) return;
+
     listSetters[from]((prev) =>
       prev.filter((i) => i.name !== item.name)
     );
-    listSetters[to]((prev) => [...prev, item]);
-  };
+    listSetters[to]((prev) =>
+      prev.some((i) => i.name === item.name) ? prev : [...prev, item]
+    );
 
-  const moveToMainList = (item: Item) => {
-    moveItemBetweenLists(item, item.type as ColumnType, 'Main');
+    if (delayBackToMain) {
+      lockItem(item, 5000, () => {
+        moveItemBetweenLists(item, to, 'Main');
+      });
+    }
   };
 
   const handleMainItemClick = (item: Item) => {
-    moveItemBetweenLists(item, 'Main', item.type as ColumnType);
-
-    setTimeout(() => {
-      moveToMainList(item);
-    }, 5000);
+    moveItemBetweenLists(item, 'Main', item.type as ColumnType, true);
   };
 
   const handleFruitItemClick = (item: Item) => {
+    cancelLock(item);
     moveItemBetweenLists(item, 'Fruit', 'Main');
   };
 
   const handleVegetableItemClick = (item: Item) => {
+    cancelLock(item);
     moveItemBetweenLists(item, 'Vegetable', 'Main');
   };
 
   const handleOnDropItemToMainList = (item: Item) => {
+    cancelLock(item);
     moveItemBetweenLists(item, item.type as ColumnType, 'Main');
   };
 
   const handleOnDropItemToFruitList = (item: Item) => {
-    moveItemBetweenLists(item, 'Main', 'Fruit');
-    setTimeout(() => moveToMainList(item), 5000);
+    moveItemBetweenLists(item, 'Main', 'Fruit', true);
   };
 
   const handleOnDropItemToVegetableList = (item: Item) => {
-    moveItemBetweenLists(item, 'Main', 'Vegetable');
-    setTimeout(() => moveToMainList(item), 5000);
+    moveItemBetweenLists(item, 'Main', 'Vegetable', true);
   };
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useRef, useState } from 'react';
 import { Column } from '@/components/Column';
 import { initialItems } from '@/constant/item';
 import { ColumnType, Item } from '@/@types/item';
@@ -16,7 +16,7 @@ export default function Page() {
 
   const listSetters: Record<
     ColumnType,
-    React.Dispatch<React.SetStateAction<Item[]>>
+    Dispatch<SetStateAction<Item[]>>
   > = {
     Main: setMainList,
     Fruit: setFruitList,


### PR DESCRIPTION

Feature | Details
-- | --
transitionMapRef | Stores per-item timers to track state transitions
lockItem | Prevents multiple triggers per item during transitions
cancelLock | Cancels lock when item is returned (by click or drop)
delayBackToMain | Flag to auto-move item back to main after 5 seconds
onExpire | Executes after lock expires (e.g., auto-return to main)